### PR TITLE
Potential fix for code scanning alert no. 7: DOM text reinterpreted as HTML

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -24,6 +24,7 @@
         "@types/react-dom": "19.2.3",
         "@vitejs/plugin-react": "^6.0.1",
         "css-select": "6.0.0",
+        "dompurify": "3.4.0",
         "eslint": "9.39.2",
         "eslint-plugin-react-hooks": "7.0.1",
         "eslint-plugin-react-refresh": "0.4.26",
@@ -1136,9 +1137,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1154,9 +1152,6 @@
       "integrity": "sha512-V6/wZztnBqlx5hJQqNWwFdxIKN0m38p8Jas+VoSfgH54HSj9tKTt1dZvG6JRHcjh6D7TvrJPWFGaY9UBVOaWPw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1174,9 +1169,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1192,9 +1184,6 @@
       "integrity": "sha512-nWwpvUSPkoFmZo0kQazZYOrT7J5DGOJ/+QHHzjvNlooDZED8oH82Yg67HvehPPLAg5fUff7TfWFHQS8IV1n3og==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -1212,9 +1201,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1230,9 +1216,6 @@
       "integrity": "sha512-Jpw/0iwoKWx3LJ2rc1yjFrj+T7iHZn2JDg1Yny1ma0luviFS4mhAIcd1LFNxK3EYu3DHWCps0ydXQ5i/rrJ2ig==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1781,6 +1764,13 @@
       "dependencies": {
         "@types/jest": "*"
       }
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.53.0",
@@ -2510,6 +2500,15 @@
       },
       "funding": {
         "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.0.tgz",
+      "integrity": "sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/domutils": {
@@ -3367,9 +3366,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3389,9 +3385,6 @@
       "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -3413,9 +3406,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3435,9 +3425,6 @@
       "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,

--- a/client/package.json
+++ b/client/package.json
@@ -33,7 +33,7 @@
     "vite-plugin-svgr": "4.3.0",
     "vite-tsconfig-paths": "5.1.4",
     "zustand": "5.0.12",
-    "dompurify": "^3.4.0"
+    "dompurify": "3.4.0"
   },
   "scripts": {
     "start": "vite --host",

--- a/client/package.json
+++ b/client/package.json
@@ -32,7 +32,8 @@
     "typescript-eslint": "8.53.0",
     "vite-plugin-svgr": "4.3.0",
     "vite-tsconfig-paths": "5.1.4",
-    "zustand": "5.0.12"
+    "zustand": "5.0.12",
+    "dompurify": "^3.4.0"
   },
   "scripts": {
     "start": "vite --host",

--- a/client/src/components/home/common/typography/GenesysDescriptionTypography.tsx
+++ b/client/src/components/home/common/typography/GenesysDescriptionTypography.tsx
@@ -1,4 +1,5 @@
 import {Typography} from '@mui/material';
+import DOMPurify from 'dompurify';
 
 interface Props {
     text: string;
@@ -75,6 +76,11 @@ export default function GenesysDescriptionTypography(props: Props) {
         return final;
     };
 
+    const sanitizedHtml = DOMPurify.sanitize(checkText(), {
+        ALLOWED_TAGS: ['i', 'b'],
+        ALLOWED_ATTR: ['class']
+    });
+
     return <Typography variant={variant} component="div" sx={sx} style={{wordWrap: 'break-word', textAlign: 'center'}}
-                       dangerouslySetInnerHTML={{__html: checkText()}}/>;
+                       dangerouslySetInnerHTML={{__html: sanitizedHtml}}/>;
 }


### PR DESCRIPTION
Potential fix for [https://github.com/GenravenGenesys/genesys/security/code-scanning/7](https://github.com/GenravenGenesys/genesys/security/code-scanning/7)

General fix: never pass untrusted raw strings into `dangerouslySetInnerHTML` unless sanitized. Here, the best fix is to sanitize the final HTML string in `GenesysDescriptionTypography` before assigning it to `__html`, while preserving existing token-to-icon behavior.

Best targeted fix (without changing functionality):
- **File:** `client/src/components/home/common/typography/GenesysDescriptionTypography.tsx`
- Add import for a well-known sanitizer: `dompurify`.
- Keep `checkText()` logic as-is (so token rendering behavior remains unchanged).
- Sanitize `checkText()` output with a strict allowlist that only permits tags/attributes the component needs (`i`, `b`, `class`).
- Use the sanitized result in `dangerouslySetInnerHTML`.

No change is required in `InlineTextField.tsx` for this specific sink fix.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
